### PR TITLE
update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Checks if the user who triggered the worfklow (actor) doesn't belong to the `oct
      username: ${{ github.actor }}
      team: 'octocats'
      GITHUB_TOKEN: ${{ secrets.PAT }}
-- if: ${{ !steps.checkUserMember.outputs.isTeamMember }}
+- if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
   ...  
 ```
 


### PR DESCRIPTION
I don't know if this is recent, but in github docs its says Job outputs are strings. So the if does not work with `!` notation.
I could make it work using this comparisson notation `== 'false'` instead.

Sauce: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs#:~:text=Job%20outputs%20are%20strings%2C