### PR TITLE
#11 - Upgrade from Node12 to Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ outputs:
   isTeamMember:
     description: 'Predicate to indicate if user belongs to team'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
In preparation for the sunset of Node12 Github has started showing warnings in all their workflows to upgrade all actions from Node12 to Node16.
    
Ref: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Fixes #11