### PR TITLE
docs(readme): add note about fine-grained personal access token permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ See [action.yml](action.yml)
 
 ## Requirements
 
-In order to use this action you need to use a [personal access token] 
-with `read:org` [scope](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps#available-scopes) 
-(so the builtin in [GITHUB_TOKEN](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) is not enough)
+In order to use this action you need to use a [personal access token (classic)] with `read:org` [scope](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps#available-scopes) (so the builtin in [GITHUB_TOKEN](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) is not enough), or a [fine-grained personal access token] with `Organization permissions > Members > Read-only` scope.
+
 
 > **Warning** If you are using GitHub Enterprise Server, this version is only supported on GHES 3.4 or Later. Use v1 if you want to use it on an older GHES installation
 


### PR DESCRIPTION
Thank you for such a great tool😀

GitHub recently made "Fine-grained Personal Access Token" generally available.
https://github.blog/changelog/2025-03-18-fine-grained-pats-are-now-generally-available/

I confirmed that this action also works with a Fine-grained Personal Access Token.

![image](https://github.com/user-attachments/assets/7085c413-a17d-4dd0-858b-68d1ea968597)

So I updated the README accordingly. Thanks!