### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration tests.yml
+++ b/.github/workflows/integration tests.yml
@@ -1,4 +1,6 @@
 name: integration tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/tspascoal/get-user-teams-membership/security/code-scanning/3](https://github.com/tspascoal/get-user-teams-membership/security/code-scanning/3)

In general, the fix is to define an explicit `permissions:` block for this workflow (or specifically for the `test` job) granting only read access to repository contents, since the steps only check out code and run tests and do not push changes, create releases, or modify issues/PRs via `GITHUB_TOKEN`.

The best minimal fix without changing functionality is to add a workflow-level `permissions:` block directly under the `name:` line, before the `on:` section, with `contents: read`. `actions/checkout` requires only read access to repository contents; all other privileged operations use the separate application token (`steps.get_workflow_token.outputs.token`), not `GITHUB_TOKEN`. No other scopes (like `pull-requests` or `issues`) are clearly needed in the provided snippet. No imports or extra definitions are required since this is a YAML configuration change only.

Concretely, edit `.github/workflows/integration tests.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: integration tests`). No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
