### PR TITLE
Improve performance by increasing the page size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { getInput, setOutput, setFailed } from '@actions/core'
+import { getInput, setOutput, setFailed, debug } from '@actions/core'
 import { getOctokit, context } from '@actions/github'
 
 run()
@@ -20,7 +20,7 @@ async function run() {
                 id
             }
             organization(login: $org) {
-              teams (first:1, userLogins: $userLogins, after: $cursor) { 
+              teams (first:100, userLogins: $userLogins, after: $cursor) { 
                   nodes {
                     name
                 }
@@ -52,6 +52,8 @@ async function run() {
             }))
 
             cursor = data.organization.teams.pageInfo.endCursor
+
+            debug(`Got teams: ${teams.join(",")}. Has next page: ${data.organization.teams.pageInfo.hasNextPage}`)
         } while (data.organization.teams.pageInfo.hasNextPage)
 
         const isTeamMember = teams.some((teamName) => inputTeams.includes(teamName.toLowerCase()))


### PR DESCRIPTION
Fetch multiple teams at a time instead of one by one 

**API efficiency improvements:**

* Increased the `first` parameter in the GraphQL query for teams from 1 to 100, allowing the script to fetch more teams per API call and reduce the number of requests needed.

**Debugging and logging enhancements:**

* Added the `debug` function from `@actions/core` to the imports to enable debug logging.
* Added a debug log after fetching teams to output the list of teams retrieved and whether there are more pages, improving observability during execution.